### PR TITLE
modified package.json to run start before run build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "start": "node ./compiled/server.js",
+    "start": "npm run build && node ./compiled/server.js",
     "build": "npm run clean && npm run build:server && npm run build:src",
     "build:server": "babel ./server --out-dir ./compiled",
     "build:src": "webpack --config webpack.config.js",


### PR DESCRIPTION
npm startしたらbuildで生成されるはずのファイルがないためエラーになってしまいました。
調査不足かもしれませんがstartではbuildは実行されないのかなと思います。
（実は何かやり方がある？npmが古い？npm -v -> 3.10.9）
とりあえずpackage.jsonのstartコマンドにbuildを追加しました。
内容的には多分issueの方が良いと思いますが、せっかくなのでPRを試してみました。